### PR TITLE
Fix recipe URLs and Tufte-CSS style application

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,7 +6,7 @@ import {RecipeComponent} from "./pages/recipes/recipe/recipe.component";
 
 const routes: Routes = [
   {
-    path: "recipe/:slug",
+    path: "recipes/:slug",
     component: RecipeComponent
   },
   {

--- a/src/app/pages/recipes/recipe/recipe.component.html
+++ b/src/app/pages/recipes/recipe/recipe.component.html
@@ -1,7 +1,3 @@
 <article>
-<section>
-  <markdown
-    src="assets/recipes/{{slug}}.md">
-  </markdown>
-</section>
+<section markdown src="assets/recipes/{{slug}}.md"></section>
 </article>

--- a/src/assets/recipes/burgundarkassa.md
+++ b/src/assets/recipes/burgundarkassa.md
@@ -26,7 +26,7 @@ Gott að bera fram með kartöflumús, saxaðri steinselju, og rauðvínsflösku
 1. Pressið hvítlaukinn eða saxið smátt.
 1. Skerið sveppina í fjórðunga.
 
-## Eldun - fyrri skref
+## Eldun
 
 Fyrri skref eru nokkurn veginn eins hvort sem hraðsuðupottur eða venjulegur pottur er notaður. Munurinn er helst að sveppirnir eru soðnir skemur í venjulegum potti.
 

--- a/src/assets/recipes/burgundarkassa.md
+++ b/src/assets/recipes/burgundarkassa.md
@@ -1,39 +1,52 @@
 # Búrgundarkássa
 
-Rauðvín, nautakjöt og perlulaukar
+Rauðvín, nautakjöt og perlulaukar.
 
 ## Hráefni
 
 * 1 klípa smjör
-* 200 g beikonbitar
-* 500 g nautakjöt
-* 4 hvítlauksgeirar
-* 200g perlulaukar
-* 1 stk gulrót, stór
-* 500 mL rauðvín
-* 1 búnt lárviðarlauf, fersk
-* 1 búnt timjan, ferskt
-* 1 búnt rósmarín, ferskt
-* 250 g kastaníusveppir
+* 200g beikonbitar
+* 500g nautakjöt
 * 2 msk hveiti
-* 1 dós tómatpúrra
+* 4 hvítlauksgeirar
+* 200g perlulaukar eða litlir skalottulaukar
+* 1 stk gulrót, stór
+* 500mL rauðvín
+* 1 dós (um 140g) tómatpúrra
+* 250g kastaníusveppir
+* Lárviðarlauf, timjan og rósmarín, salt og pipar eftir smekk. 
+
+Gott að bera fram með kartöflumús, saxaðri steinselju, og rauðvínsflösku til viðbótar.
 
 ## Undirbúningur
 
-1. Fjarlægið hýðið af perlulaukunum. 
-1. Skerið nautakjötið í bita (gúllasstærð). 
-1. Saxið gulrótina í stóra bita. 
-1. Pressið hvítlaukinn. 
-1. Skerið sveppina í fjórðunga (auðvelt að gera á meðan kássan mallar)
+1. Fjarlægið hýðið af perlulaukunum en ekki skera þá niður að öðru leyti. Þetta tekur tíma.
+1. Skerið nautakjötið í gúllasstærð. 
+1. Saxið gulrótina í stóra bita.
+1. Pressið hvítlaukinn eða saxið smátt.
+1. Skerið sveppina í fjórðunga.
 
-## Eldun
+## Eldun - fyrri skref
 
-1. Bræðið smjörið á háum hita í stórum potti.
-1. Brúnið beikonbitana upp úr smjörinu.
-1. Fjarlægið bitana úr pottinum og geymið til hliðar.
-1. Brúnið kjötið í beikonfitunni og smjörinu sem eftir urðu í pottinum og dreifið hveitinu svo yfir.
-1. Bætið hvítlauknum, perlulaukunum og gulrótinni við og steikið í 3 mínútur.
-1. Bætið víni, tómatpúrru, beikonbitum og kryddjurtum við og hrærið saman.
-1. Látið malla í 3 tíma á lágum hita með loki. Bætið við víni ef á þarf að halda.
-1. Bætið sveppum við þegar um klukkutími er eftir af suðunni.
-1. Smakkið til með salti og pipar.
+Fyrri skref eru nokkurn veginn eins hvort sem hraðsuðupottur eða venjulegur pottur er notaður. Munurinn er helst að sveppirnir eru soðnir skemur í venjulegum potti.
+
+Þessi skref má gera með "Saute" stillingu á hraðsuðupotti. Sé venjulegur pottur notaður er betra að hafa hann í stærri kantinum.
+
+1. Bræðið smjörið. Brúnið beikonbitana upp úr því, um 3-4 mínútur.
+1. Fjarlægið beikonbitana úr pottinum og geymið til hliðar.
+1. Brúnið kjötið í beikonfitunni og smjörinu sem eftir urðu í pottinum, um 3-4 mínútur. Dreifið hveitinu svo yfir.
+1. Bætið hvítlauknum, perlulaukunum og gulrótinni við og steikið í 3-4 mínútur. Ef gumsið er byrjar að brenna við má byrja að bæta við víninu.
+1. Bætið víni og tómatpúrru við og skrapið allt sem hefur brúnast upp af botninum.
+1. Bætið beikonbitum (aftur) við ásamt kryddjurtum, salt og pipar, og hrærið öllu saman.
+
+### Suða - hraðsuðupottur
+
+7. Bætið kastaníusveppunum við.
+8. Lokið hraðsuðupottinum og stillið á þrýstisuðu í 45 mínútur.
+9. Þegar suðunni er lokið, leyfið þrýstingnum að jafna sig í 10 mínútur, sleppið svo þrýstingnum af ef þrýstijöfnun er ekki þegar náð.
+10. Takið lokið af, notið "Saute" stillingu og hrærið í 5-10 mínútur til að þykkja kássuna.
+
+### Suða - klassísk
+
+7. Látið malla í 2 tíma á lágum hita með loki. Bætið við víni ef á þarf að halda.
+8. Bætið kastaníusveppunum við og sjóðið í klukkutíma til viðbótar.


### PR DESCRIPTION
The `/recipes` slug was not pluralized when looking at individual recipes, let's fix that.

Also, some of the Tufte-CSS styles were not being applied due to the `<Markdown>` component interfering with child selectors, so we flatten the HTML elements.

Also update the Búrgúndarkássa recipe.