### PR TITLE
Fix build target directory after the Angular 18 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "npm run collect-recipes && ng build --watch --configuration development",
     "test": "ng test",
     "collect-recipes": "node scripts/recipe-collection.js",
-    "deploy": "npm run collect-recipes && ng deploy --build-target=ernir-angular --dir=dist/ernir-angular/"
+    "deploy": "npm run collect-recipes && ng deploy --dir=dist/ernir-angular/browser"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
I read the directory target path in [angular-cli-ghpages](https://github.com/angular-schule/angular-cli-ghpages?tab=readme-ov-file#changelog) wrong, was missing `/browser` and seeing nothing but 404s.

