### PR TITLE
Use a version of Tufte CSS from CDN

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/assets/tufte-css"]
-	path = src/assets/tufte-css
-	url = git@github.com:edwardtufte/tufte-css.git

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
 .angular
 .idea
 dist
-src/assets/tufte-css

--- a/angular.json
+++ b/angular.json
@@ -20,7 +20,7 @@
             "polyfills": ["src/polyfills.ts"],
             "tsConfig": "tsconfig.app.json",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.css", "src/assets/tufte-css/tufte.css"],
+            "styles": ["src/styles.css", "https://cdnjs.cloudflare.com/ajax/libs/tufte-css/1.8.0/tufte.min.css"],
             "scripts": ["node_modules/marked/marked.min.js"],
             "browser": "src/main.ts"
           },


### PR DESCRIPTION
Looks like it works fine to just reference a CDN URL in the styles object, and we then don't need to lug a submodule around?