### PR TITLE
Drop zone.js from the Angular dependency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
           - "rxjs*"
           - "karma*"
           - "jasmine*"
-          - "zone*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
As it looks like this is not actually in sync with the rest