### PR TITLE
Revert "Bump ngx-markdown from 20.0.0 to 20.1.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/platform-browser-dynamic": "^20.3.2",
         "@angular/router": "^20.3.2",
         "gray-matter": "^4.0.3",
-        "ngx-markdown": "^20.1.0",
+        "ngx-markdown": "^20.0.0",
         "rxjs": "~7.8.2",
         "tslib": "^2.8.1",
         "zone.js": "~0.15.1"
@@ -13971,9 +13971,10 @@
       "dev": true
     },
     "node_modules/ngx-markdown": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-20.1.0.tgz",
-      "integrity": "sha512-BLn6CTMO27cU0zeaJYoC1g5c1hAkrpE5oqVSQFGW0J5gq+gEuvTt4vrtNLc8Z+HYXtuuWmuhUWiXL/bYoiDJ+A==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-20.0.0.tgz",
+      "integrity": "sha512-AtB0EhYlfZbNBFzzhOkqxw5tIX+Z1rLqkRP207ee8c3QHQTn/uRmVVTMwE7LenF2ZOW11Brq/O8h6VfLy9FG+w==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -13988,7 +13989,7 @@
         "@angular/common": "^20.0.0",
         "@angular/core": "^20.0.0",
         "@angular/platform-browser": "^20.0.0",
-        "marked": "^15.0.0 || ^16.0.0",
+        "marked": "^15.0.0",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0"
       }
@@ -27297,9 +27298,9 @@
       "dev": true
     },
     "ngx-markdown": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-20.1.0.tgz",
-      "integrity": "sha512-BLn6CTMO27cU0zeaJYoC1g5c1hAkrpE5oqVSQFGW0J5gq+gEuvTt4vrtNLc8Z+HYXtuuWmuhUWiXL/bYoiDJ+A==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-20.0.0.tgz",
+      "integrity": "sha512-AtB0EhYlfZbNBFzzhOkqxw5tIX+Z1rLqkRP207ee8c3QHQTn/uRmVVTMwE7LenF2ZOW11Brq/O8h6VfLy9FG+w==",
       "requires": {
         "clipboard": "^2.0.11",
         "emoji-toolkit": ">= 8.0.0 < 10.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "^20.3.2",
     "@angular/router": "^20.3.2",
     "gray-matter": "^4.0.3",
-    "ngx-markdown": "^20.1.0",
+    "ngx-markdown": "^20.0.0",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
     "zone.js": "~0.15.1"


### PR DESCRIPTION
This reverts commit 03d54eef2aaca8ae7c6461709b340e3cebc7d4d6 because it breaks the build